### PR TITLE
chore: update readme link ref to graspologic

### DIFF
--- a/.yarn/versions/dc16934b.yml
+++ b/.yarn/versions/dc16934b.yml
@@ -1,0 +1,2 @@
+declined:
+  - "@graspologic/monorepo"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   - Supports [**ReactJS**](https://reactjs.org/) or standalone.
 - Contains experimental implementations of a few popular graph layout algorithms that work directly with the graph renderer.
 
-**graspologic-js** is a companion library to [**topologic**](https://github.com/microsoft/topologic), which is a python library for intelligently building networks and network embeddings, and for analyzing connected data.
+**graspologic-js** is a companion library to [**graspologic**](https://github.com/microsoft/graspologic), which is a python library for intelligently building networks and network embeddings, and for analyzing connected data.
 
 ## 🌐Browser Compatibility
 


### PR DESCRIPTION
updated readme link from topologic to graspologic