### PR TITLE
Update package.json to include the repository

### DIFF
--- a/packages/libs/animation/package.json
+++ b/packages/libs/animation/package.json
@@ -3,6 +3,11 @@
 	"version": "0.6.0",
 	"description": "Graphical primitives",
 	"author": "Chris Trevino (chtrevin@microsoft.com)",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/graspologic-js.git",
+		"directory": "packages/libs/animation"
+	},
 	"contributors": [
 		"David Tittsworth (datittsw@microsoft.com)"
 	],

--- a/packages/libs/camera/package.json
+++ b/packages/libs/camera/package.json
@@ -3,6 +3,11 @@
 	"version": "0.6.0",
 	"license": "MIT",
 	"description": "Contains a camera implementation used within @graspologic",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/graspologic-js.git",
+		"directory": "packages/libs/camera"
+	},
 	"main": "src/index.ts",
 	"publishConfig": {
 		"main": "dist/cjs/index.js",

--- a/packages/libs/common/package.json
+++ b/packages/libs/common/package.json
@@ -3,6 +3,11 @@
 	"version": "0.6.0",
 	"license": "MIT",
 	"description": "A common set of types and utils used by graspologic",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/graspologic-js.git",
+		"directory": "packages/libs/common"
+	},
 	"main": "src/index.ts",
 	"publishConfig": {
 		"main": "dist/cjs/index.js",

--- a/packages/libs/controls-react/package.json
+++ b/packages/libs/controls-react/package.json
@@ -3,6 +3,11 @@
 	"version": "0.6.0",
 	"description": "React-components for dat.gui controls for adjusting graph-view rendering",
 	"author": "Chris Trevino (chtrevin@microsoft.com)",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/graspologic-js.git",
+		"directory": "packages/libs/controls-react"
+	},
 	"contributors": [
 		"David Tittsworth (datittsw@microsoft.com)",
 		"Nathan Evans (naevans@microsoft.com)"

--- a/packages/libs/controls/package.json
+++ b/packages/libs/controls/package.json
@@ -3,6 +3,11 @@
 	"version": "0.6.0",
 	"description": "dat.gui controls for adjusting graph-view rendering",
 	"author": "Chris Trevino (chtrevin@microsoft.com)",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/graspologic-js.git",
+		"directory": "packages/libs/controls"
+	},
 	"contributors": [
 		"David Tittsworth (datittsw@microsoft.com)",
 		"Nathan Evans (naevans@microsoft.com)"

--- a/packages/libs/graph/package.json
+++ b/packages/libs/graph/package.json
@@ -3,6 +3,11 @@
 	"version": "0.6.0",
 	"license": "MIT",
 	"main": "src/index.ts",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/graspologic-js.git",
+		"directory": "packages/libs/graph"
+	},
 	"publishConfig": {
 		"main": "dist/cjs/index.js",
 		"module": "dist/esm/index.js",

--- a/packages/libs/layout-core/package.json
+++ b/packages/libs/layout-core/package.json
@@ -3,6 +3,11 @@
 	"version": "0.6.0",
 	"license": "MIT",
 	"main": "src/index.ts",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/graspologic-js.git",
+		"directory": "packages/libs/layout-core"
+	},
 	"publishConfig": {
 		"main": "dist/cjs/index.js",
 		"module": "dist/esm/index.js",

--- a/packages/libs/layout-fa2/package.json
+++ b/packages/libs/layout-fa2/package.json
@@ -3,6 +3,11 @@
 	"version": "0.6.0",
 	"license": "MIT",
 	"main": "src/index.ts",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/graspologic-js.git",
+		"directory": "packages/libs/layout-fa2"
+	},
 	"publishConfig": {
 		"main": "dist/cjs/index.js",
 		"module": "dist/esm/index.js",

--- a/packages/libs/luma-utils/package.json
+++ b/packages/libs/luma-utils/package.json
@@ -3,6 +3,11 @@
 	"main": "src/index.ts",
 	"description": "A set of luma utils used within graspologic",
 	"version": "0.6.0",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/graspologic-js.git",
+		"directory": "packages/libs/luma-utils"
+	},
 	"license": "MIT",
 	"publishConfig": {
 		"main": "dist/cjs/index.js",

--- a/packages/libs/memstore/package.json
+++ b/packages/libs/memstore/package.json
@@ -3,6 +3,11 @@
 	"version": "0.6.0",
 	"license": "MIT",
 	"main": "src/index.ts",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/graspologic-js.git",
+		"directory": "packages/libs/memstore"
+	},
 	"publishConfig": {
 		"main": "dist/cjs/index.js",
 		"module": "dist/esm/index.js",

--- a/packages/libs/react/package.json
+++ b/packages/libs/react/package.json
@@ -3,6 +3,11 @@
 	"version": "0.6.0",
 	"description": "Graph Dataviz for React",
 	"main": "src/index.ts",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/graspologic-js.git",
+		"directory": "packages/libs/react"
+	},
 	"publishConfig": {
 		"main": "dist/cjs/index.js",
 		"module": "dist/esm/index.js",

--- a/packages/libs/renderer-glsl/package.json
+++ b/packages/libs/renderer-glsl/package.json
@@ -3,6 +3,11 @@
 	"version": "0.6.0",
 	"description": "Graph data visualization core renderer (GLSL Code)",
 	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/graspologic-js.git",
+		"directory": "packages/libs/renderer-glsl"
+	},
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
 	"types": "dist/types/index.d.ts",

--- a/packages/libs/renderer/package.json
+++ b/packages/libs/renderer/package.json
@@ -3,6 +3,11 @@
 	"version": "0.6.0",
 	"description": "Graph data visualization core renderer",
 	"main": "src/index.ts",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/graspologic-js.git",
+		"directory": "packages/libs/renderer"
+	},
 	"publishConfig": {
 		"main": "dist/cjs/index.js",
 		"module": "dist/esm/index.js",

--- a/packages/renderables/base/package.json
+++ b/packages/renderables/base/package.json
@@ -3,6 +3,11 @@
 	"main": "src/index.ts",
 	"description": "A set of base classes used for renderables within graspologic",
 	"version": "0.6.0",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/graspologic-js.git",
+		"directory": "packages/renderables/base"
+	},
 	"license": "MIT",
 	"publishConfig": {
 		"main": "dist/cjs/index.js",

--- a/packages/renderables/edges/package.json
+++ b/packages/renderables/edges/package.json
@@ -3,6 +3,11 @@
 	"main": "src/index.ts",
 	"description": "The edge renderer contained within graspologic",
 	"version": "0.6.0",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/graspologic-js.git",
+		"directory": "packages/renderables/edges"
+	},
 	"license": "MIT",
 	"publishConfig": {
 		"main": "dist/cjs/index.js",

--- a/packages/renderables/nodes/package.json
+++ b/packages/renderables/nodes/package.json
@@ -3,6 +3,11 @@
 	"main": "src/index.ts",
 	"description": "The node renderer contained within graspologic",
 	"version": "0.6.0",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/graspologic-js.git",
+		"directory": "packages/renderables/nodes"
+	},
 	"license": "MIT",
 	"publishConfig": {
 		"main": "dist/cjs/index.js",

--- a/packages/renderables/support/package.json
+++ b/packages/renderables/support/package.json
@@ -3,6 +3,11 @@
 	"main": "src/index.ts",
 	"description": "A set of support renderables within graspologic",
 	"version": "0.6.0",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/graspologic-js.git",
+		"directory": "packages/renderables/support"
+	},
 	"license": "MIT",
 	"publishConfig": {
 		"main": "dist/cjs/index.js",


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@rancyr](https://github.com/v-rr), [@Jaydon Peng](https://github.com/v-jiepeng), [@Zhongpeng Zhou](https://github.com/v-zhzhou) and [@Jingying Gu](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* @graspologic/renderer-glsl
* @graspologic/renderer
* @graspologic/render-controls-react
* @graspologic/render-controls
* @graspologic/renderables-support
* @graspologic/renderables-nodes
* @graspologic/renderables-edges
* @graspologic/renderables-base
* @graspologic/react
* @graspologic/memstore
* @graspologic/luma-utils
* @graspologic/layout-fa2
* @graspologic/layout-core
* @graspologic/graph
* @graspologic/common
* @graspologic/camera
* @graspologic/animation